### PR TITLE
Clear old blocks during startup

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -50,11 +50,13 @@ Start looking for new blocks
 @method init
 */
 EthBlocks.init = function(){
-
     if(typeof web3 === 'undefined') {
         console.warn('EthBlocks couldn\'t find web3, please make sure to instantiate a web3 object before calling EthBlocks.init()');
         return;
     }
+
+    // clear current block list
+    EthBlocks.clear();
 
     Tracker.nonreactive(function() {
         observeLatestBlocks();


### PR DESCRIPTION
As part of the overall refactoring of the codebase to ensure all network-related data is stored against a network id, this change ensures that old block data is cleared out before loading in new block data (in case the user is a different another network since the last time the app ran).
- ethereum/meteor-dapp-wallet#276
- ethereum/mist#1049
- ethereum/meteor-package-accounts#2
- ethereum/meteor-package-blocks#1
